### PR TITLE
Supports DEV pricing

### DIFF
--- a/contracts/ERC20SimpleCollections.sol
+++ b/contracts/ERC20SimpleCollections.sol
@@ -23,6 +23,7 @@ contract ERC20SimpleCollections is ITokenURIDescriptor, OwnableUpgradeable {
 	mapping(address => mapping(bytes32 => Image)) public propertyImages;
 	mapping(address => mapping(uint256 => uint256)) public stakedAmountAtMinted;
 	mapping(address => bool) public allowlistedTokens;
+	address public devToken;
 
 	function initialize(address _contract) external initializer {
 		__Ownable_init();
@@ -49,6 +50,10 @@ contract ERC20SimpleCollections is ITokenURIDescriptor, OwnableUpgradeable {
 
 	function denyListToken(address _token) external onlyOwner {
 		allowlistedTokens[_token] = false;
+	}
+
+	function setDevToken(address _dev) external onlyOwner {
+		devToken = _dev;
 	}
 
 	function image(
@@ -133,15 +138,23 @@ contract ERC20SimpleCollections is ITokenURIDescriptor, OwnableUpgradeable {
 			return false;
 		}
 
-		// Always only allow staking via the SwapAndStake contract.
-		IDynamicTokenSwapAndStake.Amounts memory stakeVia = swapAndStake
-			.gatewayOf(img.gateway);
+		bool valid;
 
-		// Validate the staking position.
-		bool valid = img.requiredTokenAmount <= stakeVia.input &&
-			img.requiredTokenFee <= stakeVia.fee &&
-			allowlistedTokens[img.token] && // Ensure other contract are using allowlisted tokens.
-			img.token == stakeVia.token; // Validate that token used is same as expected token.
+		if (img.token == devToken) {
+			// Validate the staking position.
+			valid = img.requiredTokenAmount <= _positions.amount;
+		} else {
+			// Always only allow staking via the SwapAndStake contract.
+			IDynamicTokenSwapAndStake.Amounts memory stakeVia = swapAndStake
+				.gatewayOf(img.gateway);
+
+			// Validate the staking position.
+			valid =
+				img.requiredTokenAmount <= stakeVia.input &&
+				img.requiredTokenFee <= stakeVia.fee &&
+				allowlistedTokens[img.token] && // Ensure other contract are using allowlisted tokens.
+				img.token == stakeVia.token; // Validate that token used is same as expected token.
+		}
 
 		if (valid) {
 			stakedAmountAtMinted[_positions.property][id] = _positions.amount;

--- a/contracts/ERC20SimpleCollections.sol
+++ b/contracts/ERC20SimpleCollections.sol
@@ -23,7 +23,7 @@ contract ERC20SimpleCollections is ITokenURIDescriptor, OwnableUpgradeable {
 	mapping(address => mapping(bytes32 => Image)) public propertyImages;
 	mapping(address => mapping(uint256 => uint256)) public stakedAmountAtMinted;
 	mapping(address => bool) public allowlistedTokens;
-	address public devToken;
+	address public dev;
 
 	function initialize(address _contract) external initializer {
 		__Ownable_init();
@@ -53,7 +53,7 @@ contract ERC20SimpleCollections is ITokenURIDescriptor, OwnableUpgradeable {
 	}
 
 	function setDevToken(address _dev) external onlyOwner {
-		devToken = _dev;
+		dev = _dev;
 	}
 
 	function image(
@@ -140,7 +140,7 @@ contract ERC20SimpleCollections is ITokenURIDescriptor, OwnableUpgradeable {
 
 		bool valid;
 
-		if (img.token == devToken) {
+		if (img.token == dev) {
 			// Validate the staking position.
 			valid = img.requiredTokenAmount <= _positions.amount;
 		} else {

--- a/contracts/test/MockLockup.sol
+++ b/contracts/test/MockLockup.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+pragma solidity 0.8.9;
+
+import "../interfaces/ISwapAndStake.sol";
+import "@devprotocol/i-s-tokens/contracts/interfaces/ITokenURIDescriptor.sol";
+import "@devprotocol/i-s-tokens/contracts/interfaces/ISTokensManagerStruct.sol";
+
+contract MockLockup {
+	address public target;
+
+	constructor(address _addr) {
+		target = _addr;
+	}
+
+	function __mock(
+		uint256 _id,
+		ISTokensManagerStruct.StakingPositions memory _positions,
+		bytes32 _key
+	) external returns (bool) {
+		bool res = ITokenURIDescriptor(target).onBeforeMint(
+			_id,
+			msg.sender,
+			_positions,
+			_key
+		);
+
+		return res;
+	}
+}

--- a/test/erc20-simple-collections.ts
+++ b/test/erc20-simple-collections.ts
@@ -448,6 +448,57 @@ describe('ERC20SimpleCollections', () => {
 
 				expect(res).to.equal(utils.parseEther('3'))
 			})
+
+			it('if the Image.token is set as DEV, onBeforeMint skips validation via SwapAndStake.gatewayOf', async () => {
+				const cont = await deployWithProxy<ERC20SimpleCollections>(
+					'ERC20SimpleCollections'
+				)
+				const lockup = await (
+					await ethers.getContractFactory('MockLockup')
+				).deploy(cont.address)
+				const swapAndStake = await (
+					await ethers.getContractFactory('DynamicTokenSwapAndStake')
+				).deploy(cont.address)
+
+				const [owner, gateway, dev] = await ethers.getSigners()
+
+				const property = await (
+					await ethers.getContractFactory('Property')
+				).deploy(owner.address, 'Testing', 'TEST')
+				await cont.initialize(swapAndStake.address)
+				await cont.allowListToken(dev.address)
+				await cont.setDevToken(dev.address)
+
+				const x = utils.keccak256(utils.toUtf8Bytes('X'))
+				const devAmount = utils.parseEther('1')
+				const devFeeAmount = utils.parseEther('1')
+				await cont.setImages(
+					property.address,
+					[
+						structImage(
+							'X_SRC',
+							'X_NAME',
+							'X_DESC',
+							devAmount,
+							devFeeAmount,
+							gateway.address,
+							dev.address
+						),
+					],
+					[x]
+				)
+
+				const res = await lockup.callStatic.__mock(
+					1,
+					structPositions({
+						property: property.address,
+						amount: utils.parseEther('1'),
+					}),
+					x
+				)
+
+				expect(res).to.equal(true)
+			})
 		})
 		describe('fail', () => {
 			it('should fail to call when the calling is not internal call from SwapAndStake', async () => {
@@ -733,6 +784,57 @@ describe('ERC20SimpleCollections', () => {
 					structPositions({
 						property: property.address,
 						amount: utils.parseEther('3'),
+					}),
+					x
+				)
+
+				expect(res).to.equal(false)
+			})
+
+			it('returns false when the Image.token is set as DEV and the staked DEV is less than Image.requiredTokenAmount', async () => {
+				const cont = await deployWithProxy<ERC20SimpleCollections>(
+					'ERC20SimpleCollections'
+				)
+				const lockup = await (
+					await ethers.getContractFactory('MockLockup')
+				).deploy(cont.address)
+				const swapAndStake = await (
+					await ethers.getContractFactory('DynamicTokenSwapAndStake')
+				).deploy(cont.address)
+
+				const [owner, gateway, dev] = await ethers.getSigners()
+
+				const property = await (
+					await ethers.getContractFactory('Property')
+				).deploy(owner.address, 'Testing', 'TEST')
+				await cont.initialize(swapAndStake.address)
+				await cont.allowListToken(dev.address)
+				await cont.setDevToken(dev.address)
+
+				const x = utils.keccak256(utils.toUtf8Bytes('X'))
+				const devAmount = utils.parseEther('1')
+				const devFeeAmount = utils.parseEther('0')
+				await cont.setImages(
+					property.address,
+					[
+						structImage(
+							'X_SRC',
+							'X_NAME',
+							'X_DESC',
+							devAmount,
+							devFeeAmount,
+							gateway.address,
+							dev.address
+						),
+					],
+					[x]
+				)
+
+				const res = await lockup.callStatic.__mock(
+					1,
+					structPositions({
+						property: property.address,
+						amount: utils.parseEther('0.99999'),
 					}),
 					x
 				)
@@ -1235,6 +1337,35 @@ describe('ERC20SimpleCollections', () => {
 				expect(owner).to.equal(addr1.address)
 				expect(await cont.swapAndStake()).to.equal(swapAndStake.address)
 				expect(await cont.allowlistedTokens(token.address)).to.equal(true)
+			})
+		})
+	})
+
+	describe('devToken', () => {
+		describe('success', () => {
+			it('set devToken address', async () => {
+				const cont = await deployWithProxy<ERC20SimpleCollections>(
+					'ERC20SimpleCollections'
+				)
+				const [, addr2, dev] = await ethers.getSigners()
+				await cont.initialize(addr2.address)
+
+				await cont.setDevToken(dev.address)
+				const devToken = await cont.devToken()
+				expect(devToken).to.equal(dev.address)
+			})
+		})
+		describe('fail', () => {
+			it('should fail to set devToken address when the caller is not owner', async () => {
+				const cont = await deployWithProxy<ERC20SimpleCollections>(
+					'ERC20SimpleCollections'
+				)
+				const [, user, addr2, dev] = await ethers.getSigners()
+				await cont.initialize(addr2.address)
+
+				await expect(
+					cont.connect(user).setDevToken(dev.address)
+				).to.be.revertedWith('Ownable: caller is not the owner')
 			})
 		})
 	})

--- a/test/erc20-simple-collections.ts
+++ b/test/erc20-simple-collections.ts
@@ -1341,9 +1341,9 @@ describe('ERC20SimpleCollections', () => {
 		})
 	})
 
-	describe('devToken', () => {
+	describe('dev', () => {
 		describe('success', () => {
-			it('set devToken address', async () => {
+			it('set dev address', async () => {
 				const cont = await deployWithProxy<ERC20SimpleCollections>(
 					'ERC20SimpleCollections'
 				)
@@ -1351,12 +1351,12 @@ describe('ERC20SimpleCollections', () => {
 				await cont.initialize(addr2.address)
 
 				await cont.setDevToken(dev.address)
-				const devToken = await cont.devToken()
+				const devToken = await cont.dev()
 				expect(devToken).to.equal(dev.address)
 			})
 		})
 		describe('fail', () => {
-			it('should fail to set devToken address when the caller is not owner', async () => {
+			it('should fail to set DEV address when the caller is not owner', async () => {
 				const cont = await deployWithProxy<ERC20SimpleCollections>(
 					'ERC20SimpleCollections'
 				)


### PR DESCRIPTION
- `dev` and `setDevToken`
- If priced by DEV, skip validation by `gatewayOf` and validate by staking position instead.